### PR TITLE
Enable GitHub Pages deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+      - run: npm install
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v2
+        with:
+          path: dist
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy
+        id: deployment
+        uses: actions/deploy-pages@v2

--- a/README.md
+++ b/README.md
@@ -7,3 +7,13 @@ A small personal finance dashboard (React + Vite + Tailwind) with:
 Run:
 1. npm install
 2. npm run dev
+
+## Deployment
+
+This project includes a GitHub Actions workflow that builds the site and deploys it to GitHub Pages. After pushing the repository to GitHub:
+
+1. Open **Settings → Pages** in the repository.
+2. Under "Build and deployment," select **GitHub Actions**.
+3. Every push to `main` will build the Vite app and publish the result to GitHub Pages.
+
+The app uses a hash-based router, so client-side navigation works correctly on GitHub Pages.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.22.3",
-    "clsx": "^1.2.1"
+    "clsx": "^1.2.1",
+    "uuid": "^11.1.0"
   },
   "devDependencies": {
     "vite": "^4.3.9",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, NavLink } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route, NavLink } from 'react-router-dom';
 import Investments from './pages/Investments.jsx';
 import Goals from './pages/Goals.jsx';
 import Liabilities from './pages/Liabilities.jsx';

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,5 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  base: './',
+});


### PR DESCRIPTION
## Summary
- add uuid dependency for list item identifiers
- switch to hash-based routing to support static hosting
- configure Vite with relative base path and add GitHub Pages workflow
- document GitHub Pages deployment steps

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6898c19ae55c8327b4f43d25e88ca187